### PR TITLE
Changes to the script to reflect the new changes in Travis CI build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,17 @@ just follow the guide below and stay notified of your build status.
 
     ![Add environment variable in Travis CI](https://i.imgur.com/UfXIoZn.png)
 
-1.  Add these lines to the `.travis-ci.yml` file of your repository.
+1.  Add these lines to the `.travis.yml` file of your repository.
 
     ```yaml
     after_success:
       - wget https://raw.githubusercontent.com/k3rn31p4nic/travis-ci-discord-webhook/master/send.sh
       - chmod +x send.sh
-      - ./send.sh success
+      - ./send.sh success $WEBHOOK_URL
     after_failure:
       - wget https://raw.githubusercontent.com/k3rn31p4nic/travis-ci-discord-webhook/master/send.sh
       - chmod +x send.sh
-      - ./send.sh failure
+      - ./send.sh failure $WEBHOOK_URL
     ```
 
 1.  Grab your coffee ☕ and enjoy! And, if you liked this, please ⭐**Star**

--- a/send.sh
+++ b/send.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 if [ -z "$2" ]; then
-  echo -e "You need to pass the WEBHOOK_URL environment variable as the second argument to this script." && exit
+  echo -e "WARNING!!"
+  echo -e "You need to pass the WEBHOOK_URL environment variable as the second argument to this script.\n For details & guide, visit: https://github.com/k3rn31p4nic/travis-ci-discord-webhook" && exit
 fi
 
 echo -e "[Webhook]: Sending webhook to Discord...\\n";

--- a/send.sh
+++ b/send.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [ -z "$WEBHOOK_URLs" ]; then
-  echo -e "WEBHOOK_URL environment variable is not defined in the settings. Unable to send webhook to Discord." && exit
+if [ -z "$2" ]; then
+  echo -e "You need to pass the WEBHOOK_URL environment variable as the second argument to this script." && exit
 fi
 
 echo -e "[Webhook]: Sending webhook to Discord...\\n";
@@ -69,5 +69,5 @@ WEBHOOK_DATA='{
   } ]
 }'
 
-(curl -v --fail --progress-bar -A "TravisCI-Webhook" -H Content-Type:application/json -H X-Author:k3rn31p4nic#8383 -d "$WEBHOOK_DATA" "$WEBHOOK_URL" \
+(curl -v --fail --progress-bar -A "TravisCI-Webhook" -H Content-Type:application/json -H X-Author:k3rn31p4nic#8383 -d "$WEBHOOK_DATA" "$2" \
   && echo -e "\\n[Webhook]: Successfully set the webhook.") || echo -e "\\n[Webhook]: Unable to send webhook."

--- a/send.sh
+++ b/send.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 if [ -z "$2" ]; then
-  echo -e "WARNING!!"
-  echo -e "You need to pass the WEBHOOK_URL environment variable as the second argument to this script.\n For details & guide, visit: https://github.com/k3rn31p4nic/travis-ci-discord-webhook" && exit
+  echo -e "WARNING!!\nYou need to pass the WEBHOOK_URL environment variable as the second argument to this script.\nFor details & guide, visit: https://github.com/k3rn31p4nic/travis-ci-discord-webhook" && exit
 fi
 
 echo -e "[Webhook]: Sending webhook to Discord...\\n";


### PR DESCRIPTION
### Description of the change
Recently, `bash` (or any) scripts in the Travis CI build were not able to access any environment variables from the Travis CI repository settings. Which is why this webhook script was not able to get the Discord webhook URL from the  `WEBHOOK_URL` environment variable (from the Travis CI repository settings).

Changes in this PR fixes that issue by passing the `WEBHOOK_URL` environment variable to the webhook script `send.sh` as an argument rather than directly trying to use the `WEBHOOK_URL` environment variable in the script.

### Additional Information
After this PR is merged with `master`, everyone using this script would require to updated their Travis CI configuration (`.travis.yml`) file as mentioned in the `README.md` file. However, if they haven't yet updated it, they would get a warning in their Travis CI build logs about this change and a link back to this repository.