### PR TITLE
Adding some colorful avatars to embeds

### DIFF
--- a/send.sh
+++ b/send.sh
@@ -10,16 +10,19 @@ case $1 in
   "success" )
     EMBED_COLOR=3066993
     STATUS_MESSAGE="Passed"
+    AVATAR="https://travis-ci.org/images/logos/TravisCI-Mascot-blue.png"
     ;;
 
   "failure" )
     EMBED_COLOR=15158332
     STATUS_MESSAGE="Failed"
+    AVATAR="https://travis-ci.org/images/logos/TravisCI-Mascot-red.png"
     ;;
 
   * )
     EMBED_COLOR=0
     STATUS_MESSAGE="Status Unknown"
+    AVATAR="https://travis-ci.org/images/logos/TravisCI-Mascot-1.png"
     ;;
 esac
 
@@ -43,12 +46,13 @@ fi
 TIMESTAMP=$(date --utc +%FT%TZ)
 WEBHOOK_DATA='{
   "username": "",
-  "avatar_url": "",
+  "avatar_url": "https://travis-ci.org/images/logos/TravisCI-Mascot-1.png",
   "embeds": [ {
     "color": '$EMBED_COLOR',
     "author": {
       "name": "Job #'"$TRAVIS_JOB_NUMBER"' (Build #'"$TRAVIS_BUILD_NUMBER"') '"$STATUS_MESSAGE"' - '"$TRAVIS_REPO_SLUG"'",
-      "url": "https://travis-ci.org/'"$TRAVIS_REPO_SLUG"'/builds/'"$TRAVIS_BUILD_ID"'"
+      "url": "https://travis-ci.org/'"$TRAVIS_REPO_SLUG"'/builds/'"$TRAVIS_BUILD_ID"'",
+      "icon_url": "'$AVATAR'"
     },
     "title": "'"$COMMIT_SUBJECT"'",
     "url": "'"$URL"'",


### PR DESCRIPTION
This PR adds some avatars to the embed object's author part, because it felt easier for me to quickly understand the build status at a glance by seeing the familiar faces.
I used the [official logos](https://travis-ci.org/logo) (which is the reason why the success one is actually blue).
The webhook's actual avatar is also changed to match the official logo.

See the example below, fired from my local machine (which explains why there's no data loaded).
![image](https://user-images.githubusercontent.com/8713616/37687372-a4ef3ae8-2c9b-11e8-94f5-5dbc80d5e586.png)
