### PR TITLE
Add support for travis-ci.com

### DIFF
--- a/send.sh
+++ b/send.sh
@@ -51,7 +51,7 @@ WEBHOOK_DATA='{
     "color": '$EMBED_COLOR',
     "author": {
       "name": "Job #'"$TRAVIS_JOB_NUMBER"' (Build #'"$TRAVIS_BUILD_NUMBER"') '"$STATUS_MESSAGE"' - '"$TRAVIS_REPO_SLUG"'",
-      "url": "https://travis-ci.org/'"$TRAVIS_REPO_SLUG"'/builds/'"$TRAVIS_BUILD_ID"'",
+      "url": "'"$TRAVIS_BUILD_WEB_URL"'",
       "icon_url": "'$AVATAR'"
     },
     "title": "'"$COMMIT_SUBJECT"'",


### PR DESCRIPTION
Use the `TRAVIS_BUILD_WEB_URL` environment variable to link to the build log instead manually creating the link to build log.

Closes https://github.com/k3rn31p4nic/travis-ci-discord-webhook/issues/5
